### PR TITLE
Implement safe communication between popup and iframe

### DIFF
--- a/popup/iframe.html
+++ b/popup/iframe.html
@@ -4,5 +4,7 @@
 </head>
 <body style="color: salmon;">
   This is one level down.
+
+  <script src="iframe.js"></script>
 </body>
 </html>

--- a/popup/iframe.html
+++ b/popup/iframe.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+</head>
+<body style="color: salmon;">
+  This is one level down.
+</body>
+</html>

--- a/popup/iframe.js
+++ b/popup/iframe.js
@@ -1,2 +1,7 @@
 console.log('iframe window.opener', window.opener)
 console.log('iframe window.parent', window.parent)
+
+window.parent.postMessage(
+  'here’s a message for my dad',
+  'chrome-extension://ofniiffbnieifjdgaeniekjkmnfgnmbb'
+)

--- a/popup/iframe.js
+++ b/popup/iframe.js
@@ -1,0 +1,2 @@
+console.log('iframe window.opener', window.opener)
+console.log('iframe window.parent', window.parent)

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <link rel="stylesheet" href="popup.css">
     <title>Chrome Addon v3: popup</title>
+    <script src="popup.js"></script>
 </head>
 <body>
     This is the <span class="special-text">HTML</span> body of the addon.

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -7,6 +7,8 @@
     <script src="popup.js"></script>
 </head>
 <body>
-    This is the <span class="special-text">HTML</span> body of the addon.
+  This is the <span class="special-text">HTML</span> body of the addon.
+
+  <iframe src="iframe.html" />
 </body>
 </html>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,2 +1,6 @@
 console.log('window.location.href', window.location.href)
 console.log('chrome.runtime.id', chrome.runtime.id)
+
+window.addEventListener('message', function(message) {
+  console.log('received a message:', message)
+})

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,0 +1,2 @@
+console.log('window.location.href', window.location.href)
+console.log('chrome.runtime.id', chrome.runtime.id)

--- a/server.js
+++ b/server.js
@@ -57,13 +57,13 @@ app.post('/register', function(req, res) {
     const { endpoint } = subscription
 
     if (!subscriptions[endpoint]) {
-      console.log(`Subscription registered: ${endpoint}`)
+      console.log(`  Subscription registered: ${endpoint}`)
       subscriptions[endpoint] = subscription
     }
 
     res.sendStatus(201)
   } catch(e) {
-    console.log('Something broke:', e)
+    console.log('  Something broke:', e)
   }
 })
 
@@ -73,7 +73,7 @@ app.post('/unregister', function(req, res) {
   const { endpoint } = subscription
 
   if (subscriptions[endpoint]) {
-    console.log(`Subscription unregistered: ${endpoint}`)
+    console.log(`  Subscription unregistered: ${endpoint}`)
     delete subscriptions[endpoint]
   }
 

--- a/server.js
+++ b/server.js
@@ -67,7 +67,7 @@ app.post('/register', function(req, res) {
   }
 })
 
-app.post('/unregister', function(req, res) {
+app.delete('/unregister', function(req, res) {
   console.log('/unregister')
   const subscription = req.body.subscription
   const { endpoint } = subscription

--- a/service-worker-utils.js
+++ b/service-worker-utils.js
@@ -3,8 +3,6 @@
 // inside the service worker.
 // The importation is done in the file `service-worker.js`.
 
-console.log("External file is also loaded!")
-
 // This function is needed because Chrome doesn't accept a base64 encoded string
 // as value for applicationServerKey in pushManager.subscribe yet
 // https://bugs.chromium.org/p/chromium/issues/detail?id=802280

--- a/service-worker.js
+++ b/service-worker.js
@@ -29,6 +29,16 @@ chrome.runtime.onSuspend.addListener(() => {
   //   started while handling this event are not guaranteed to complete.”
 
   console.log('onSuspend')
+
+  fetch('http://localhost:3003/unregister', {
+    // TODO: Include current account/user here, and access token to authorize
+    body: JSON.stringify({ subscription }),
+    headers: { 'Content-type': 'application/json' },
+    method: 'delete',
+  })
+    .then((response) => {
+      console.log('Unsubscribed')
+    })
 })
 
 self.addEventListener('push', function(event) {

--- a/service-worker.js
+++ b/service-worker.js
@@ -2,7 +2,7 @@
 // when the extension is installed or refreshed (or when you access its console).
 // It would correspond to the background script in chrome extensions v2.
 
-console.log("This prints to the console of the service worker (background script)")
+console.log('service-worker.js loaded')
 
 // Importing and using functionality from external files is also possible.
 importScripts('service-worker-utils.js')
@@ -12,12 +12,12 @@ importScripts('service-worker-utils.js')
 // The path should be relative to the file `manifest.json`.
 
 chrome.runtime.onInstalled.addListener(({ reason, previousVersion }) => {
-  console.log('Welcome to the extension!', reason, previousVersion)
+  console.log('onInstalled, reason:', reason, 'previousVersion:', previousVersion)
   initiateSubscription()
 })
 
 chrome.runtime.onStartup.addListener(() => {
-  console.log('Extension started')
+  console.log('onStartup')
   initiateSubscription()
 })
 
@@ -27,6 +27,8 @@ chrome.runtime.onSuspend.addListener(() => {
   //
   //   “Note that since the page is unloading, any asynchronous operations
   //   started while handling this event are not guaranteed to complete.”
+
+  console.log('onSuspend')
 })
 
 self.addEventListener('push', function(event) {
@@ -41,6 +43,7 @@ async function initiateSubscription() {
     return
   }
 
+  console.log('Not subscribed yet, subscribing…')
   subscribe()
 }
 


### PR DESCRIPTION
This illustrates how we could safely send message from the iframe, _i.e._ HAP, to the extension’s popup, for example to pass along the access token and account ID after the user has successfully authenticated via ID.

The extension ID is constant as it’s also used by the Chrome webstore listing; we were able to prove further that it’s not dependent on the `version` nor content of the extension either, so we might be able to hardcode it in HAP for this particular usecase (unless we find an even better approach).